### PR TITLE
Updates SKOOT's fork with latest code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run: sudo make dev-install
       - run: pip install setuptools wheel twine
-      - run: python setup.py sdist bdist_wheel
+      - run: sudo python setup.py sdist bdist_wheel
       - run: twine upload -u $USERNAME -p $PASSWORD dist/*
       - slack/status
   test-dev-tag-as-not-passed:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-fastapi
       - run: (cd .circleci/ && ./websiteFastApi.sh)
       - slack/status
   test-website-flask:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-flask
       - run: (cd .circleci/ && ./websiteFlask.sh)
       - slack/status
   test-website-django:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-django
       - run: (cd .circleci/ && ./websiteDjango.sh)
       - slack/status
   test-authreact-fastapi:
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-fastapi
       - run: (cd .circleci/ && ./authReactFastApi.sh)
       - slack/status
   test-authreact-flask:
@@ -75,7 +75,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-flask
       - run: (cd .circleci/ && ./authReactFlask.sh)
       - slack/status
   test-authreact-django:
@@ -85,7 +85,7 @@ jobs:
     steps:
       - checkout
       - run: echo "127.0.0.1 localhost.org" >> /etc/hosts
-      - run: make dev-install
+      - run: make dev-install-with-django
       - run: (cd .circleci/ && ./authReactDjango.sh)
       - slack/status
   test-success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.5.1] - 2022-03-02
+
+### Fixes:
+- Bug where a user had to add dependencies on all frameworks when using the SDK: https://github.com/supertokens/supertokens-python/issues/82
+
 ## [0.5.0] - 2022-02-03
 
 ### Breaking Change

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,16 @@ test:
 	pytest ./tests/
 
 dev-install:
-	pip3 install -e .[dev]
+	pip3 install -e .[dev] && pip3 install -e .[fastapi] && pip3 install -e .[django] && pip3 install -e .[flask]
+
+dev-install-with-fastapi:
+	pip3 install -e .[dev] && pip3 install -e .[fastapi]
+
+dev-install-with-django:
+	pip3 install -e .[dev] && pip3 install -e .[django]
+
+dev-install-with-flask:
+	pip3 install -e .[dev] && pip3 install -e .[flask]
 
 build-docs:
 	rm -rf html && pdoc --html supertokens_python

--- a/html/supertokens_python/constants.html
+++ b/html/supertokens_python/constants.html
@@ -40,7 +40,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = [&#39;2.9&#39;, &#39;2.10&#39;, &#39;2.11&#39;, &#39;2.12&#39;]
-VERSION = &#39;0.5.0&#39;
+VERSION = &#39;0.5.1&#39;
 TELEMETRY = &#39;/telemetry&#39;
 USER_COUNT = &#39;/users/count&#39;
 USER_DELETE = &#39;/user/remove&#39;

--- a/html/supertokens_python/framework/django/django_response.html
+++ b/html/supertokens_python/framework/django/django_response.html
@@ -76,7 +76,7 @@ class DjangoResponse(BaseResponse):
             key=key,
             value=value,
             expires=datetime.fromtimestamp(
-                ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %I:%M:%S&#34;),
+                ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %H:%M:%S&#34;),
             path=path,
             domain=domain,
             secure=secure,
@@ -158,7 +158,7 @@ inheritance.</p></div>
             key=key,
             value=value,
             expires=datetime.fromtimestamp(
-                ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %I:%M:%S&#34;),
+                ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %H:%M:%S&#34;),
             path=path,
             domain=domain,
             secure=secure,
@@ -241,7 +241,7 @@ inheritance.</p></div>
         key=key,
         value=value,
         expires=datetime.fromtimestamp(
-            ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %I:%M:%S&#34;),
+            ceil(expires / 1000)).strftime(&#34;%A, %B %d, %Y %H:%M:%S&#34;),
         path=path,
         domain=domain,
         secure=secure,

--- a/html/supertokens_python/framework/django/framework.html
+++ b/html/supertokens_python/framework/django/framework.html
@@ -40,14 +40,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from supertokens_python.framework.django.django_request import DjangoRequest
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 
 class DjangoFramework(Framework):
-    from django.http import HttpRequest
 
     def wrap_request(self, unwrapped: HttpRequest):
+        from supertokens_python.framework.django.django_request import \
+            DjangoRequest
         return DjangoRequest(unwrapped)</code></pre>
 </details>
 </section>
@@ -71,9 +78,10 @@ inheritance.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class DjangoFramework(Framework):
-    from django.http import HttpRequest
 
     def wrap_request(self, unwrapped: HttpRequest):
+        from supertokens_python.framework.django.django_request import \
+            DjangoRequest
         return DjangoRequest(unwrapped)</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -81,17 +89,10 @@ inheritance.</p></div>
 <li><a title="supertokens_python.framework.types.Framework" href="../types.html#supertokens_python.framework.types.Framework">Framework</a></li>
 <li>abc.ABC</li>
 </ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="supertokens_python.framework.django.framework.DjangoFramework.HttpRequest"><code class="name">var <span class="ident">HttpRequest</span></code></dt>
-<dd>
-<div class="desc"><p>A basic HTTP request.</p></div>
-</dd>
-</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="supertokens_python.framework.django.framework.DjangoFramework.wrap_request"><code class="name flex">
-<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: django.http.request.HttpRequest)</span>
+<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: HttpRequest)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -100,6 +101,8 @@ inheritance.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def wrap_request(self, unwrapped: HttpRequest):
+    from supertokens_python.framework.django.django_request import \
+        DjangoRequest
     return DjangoRequest(unwrapped)</code></pre>
 </details>
 </dd>
@@ -124,7 +127,6 @@ inheritance.</p></div>
 <li>
 <h4><code><a title="supertokens_python.framework.django.framework.DjangoFramework" href="#supertokens_python.framework.django.framework.DjangoFramework">DjangoFramework</a></code></h4>
 <ul class="">
-<li><code><a title="supertokens_python.framework.django.framework.DjangoFramework.HttpRequest" href="#supertokens_python.framework.django.framework.DjangoFramework.HttpRequest">HttpRequest</a></code></li>
 <li><code><a title="supertokens_python.framework.django.framework.DjangoFramework.wrap_request" href="#supertokens_python.framework.django.framework.DjangoFramework.wrap_request">wrap_request</a></code></li>
 </ul>
 </li>

--- a/html/supertokens_python/framework/fastapi/fastapi_middleware.html
+++ b/html/supertokens_python/framework/fastapi/fastapi_middleware.html
@@ -39,16 +39,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from starlette.middleware.base import (BaseHTTPMiddleware,
                                        RequestResponseEndpoint)
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
+
 
 class Middleware(BaseHTTPMiddleware):
-    from fastapi import FastAPI, Request
 
     def __init__(self, app: FastAPI):
         super().__init__(app)
@@ -98,7 +101,7 @@ class Middleware(BaseHTTPMiddleware):
 <dl>
 <dt id="supertokens_python.framework.fastapi.fastapi_middleware.Middleware"><code class="flex name class">
 <span>class <span class="ident">Middleware</span></span>
-<span>(</span><span>app: fastapi.applications.FastAPI)</span>
+<span>(</span><span>app: FastAPI)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -107,7 +110,6 @@ class Middleware(BaseHTTPMiddleware):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class Middleware(BaseHTTPMiddleware):
-    from fastapi import FastAPI, Request
 
     def __init__(self, app: FastAPI):
         super().__init__(app)
@@ -149,44 +151,10 @@ class Middleware(BaseHTTPMiddleware):
 <ul class="hlist">
 <li>starlette.middleware.base.BaseHTTPMiddleware</li>
 </ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.FastAPI"><code class="name">var <span class="ident">FastAPI</span></code></dt>
-<dd>
-<div class="desc"><p>Creates an application instance.</p>
-<p><strong>Parameters:</strong></p>
-<ul>
-<li><strong>debug</strong> - Boolean indicating if debug tracebacks should be returned on errors.</li>
-<li><strong>routes</strong> - A list of routes to serve incoming HTTP and WebSocket requests.</li>
-<li><strong>middleware</strong> - A list of middleware to run for every request. A starlette
-application will always automatically include two middleware classes.
-<code>ServerErrorMiddleware</code> is added as the very outermost middleware, to handle
-any uncaught errors occurring anywhere in the entire stack.
-<code>ExceptionMiddleware</code> is added as the very innermost middleware, to deal
-with handled exception cases occurring in the routing or endpoints.</li>
-<li><strong>exception_handlers</strong> - A dictionary mapping either integer status codes,
-or exception class types onto callables which handle the exceptions.
-Exception handler callables should be of the form
-<code>handler(request, exc) -&gt; response</code> and may be be either standard functions, or
-async functions.</li>
-<li><strong>on_startup</strong> - A list of callables to run on application startup.
-Startup handler callables do not take any arguments, and may be be either
-standard functions, or async functions.</li>
-<li><strong>on_shutdown</strong> - A list of callables to run on application shutdown.
-Shutdown handler callables do not take any arguments, and may be be either
-standard functions, or async functions.</li>
-</ul></div>
-</dd>
-<dt id="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.Request"><code class="name">var <span class="ident">Request</span></code></dt>
-<dd>
-<div class="desc"><p>A base class for incoming HTTP connections, that is used to provide
-any functionality that is common to both <code>Request</code> and <code>WebSocket</code>.</p></div>
-</dd>
-</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.dispatch"><code class="name flex">
-<span>async def <span class="ident">dispatch</span></span>(<span>self, request: starlette.requests.Request, call_next: Callable[[starlette.requests.Request], Awaitable[starlette.responses.Response]])</span>
+<span>async def <span class="ident">dispatch</span></span>(<span>self, request: Request, call_next: RequestResponseEndpoint)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -249,8 +217,6 @@ any functionality that is common to both <code>Request</code> and <code>WebSocke
 <li>
 <h4><code><a title="supertokens_python.framework.fastapi.fastapi_middleware.Middleware" href="#supertokens_python.framework.fastapi.fastapi_middleware.Middleware">Middleware</a></code></h4>
 <ul class="">
-<li><code><a title="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.FastAPI" href="#supertokens_python.framework.fastapi.fastapi_middleware.Middleware.FastAPI">FastAPI</a></code></li>
-<li><code><a title="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.Request" href="#supertokens_python.framework.fastapi.fastapi_middleware.Middleware.Request">Request</a></code></li>
 <li><code><a title="supertokens_python.framework.fastapi.fastapi_middleware.Middleware.dispatch" href="#supertokens_python.framework.fastapi.fastapi_middleware.Middleware.dispatch">dispatch</a></code></li>
 </ul>
 </li>

--- a/html/supertokens_python/framework/fastapi/framework.html
+++ b/html/supertokens_python/framework/fastapi/framework.html
@@ -39,15 +39,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.fastapi.fastapi_request import FastApiRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 class FastapiFramework(Framework):
-    from fastapi import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.fastapi.fastapi_request import \
+            FastApiRequest
         return FastApiRequest(unwrapped)</code></pre>
 </details>
 </section>
@@ -71,9 +77,10 @@ inheritance.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class FastapiFramework(Framework):
-    from fastapi import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.fastapi.fastapi_request import \
+            FastApiRequest
         return FastApiRequest(unwrapped)</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -81,18 +88,10 @@ inheritance.</p></div>
 <li><a title="supertokens_python.framework.types.Framework" href="../types.html#supertokens_python.framework.types.Framework">Framework</a></li>
 <li>abc.ABC</li>
 </ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="supertokens_python.framework.fastapi.framework.FastapiFramework.Request"><code class="name">var <span class="ident">Request</span></code></dt>
-<dd>
-<div class="desc"><p>A base class for incoming HTTP connections, that is used to provide
-any functionality that is common to both <code>Request</code> and <code>WebSocket</code>.</p></div>
-</dd>
-</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="supertokens_python.framework.fastapi.framework.FastapiFramework.wrap_request"><code class="name flex">
-<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: starlette.requests.Request)</span>
+<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: Request)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -101,6 +100,8 @@ any functionality that is common to both <code>Request</code> and <code>WebSocke
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def wrap_request(self, unwrapped: Request):
+    from supertokens_python.framework.fastapi.fastapi_request import \
+        FastApiRequest
     return FastApiRequest(unwrapped)</code></pre>
 </details>
 </dd>
@@ -125,7 +126,6 @@ any functionality that is common to both <code>Request</code> and <code>WebSocke
 <li>
 <h4><code><a title="supertokens_python.framework.fastapi.framework.FastapiFramework" href="#supertokens_python.framework.fastapi.framework.FastapiFramework">FastapiFramework</a></code></h4>
 <ul class="">
-<li><code><a title="supertokens_python.framework.fastapi.framework.FastapiFramework.Request" href="#supertokens_python.framework.fastapi.framework.FastapiFramework.Request">Request</a></code></li>
 <li><code><a title="supertokens_python.framework.fastapi.framework.FastapiFramework.wrap_request" href="#supertokens_python.framework.fastapi.framework.FastapiFramework.wrap_request">wrap_request</a></code></li>
 </ul>
 </li>

--- a/html/supertokens_python/framework/flask/flask_middleware.html
+++ b/html/supertokens_python/framework/flask/flask_middleware.html
@@ -39,16 +39,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from flask import Flask
+
 
 class Middleware:
-    from flask import Flask
 
     def __init__(self, app: Flask):
         self.app = app
@@ -135,7 +138,7 @@ class Middleware:
 <dl>
 <dt id="supertokens_python.framework.flask.flask_middleware.Middleware"><code class="flex name class">
 <span>class <span class="ident">Middleware</span></span>
-<span>(</span><span>app: flask.app.Flask)</span>
+<span>(</span><span>app: Flask)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -144,7 +147,6 @@ class Middleware:
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class Middleware:
-    from flask import Flask
 
     def __init__(self, app: Flask):
         self.app = app
@@ -219,117 +221,6 @@ class Middleware:
                 return result.response
             raise Exception(&#34;Shoulld never come here&#34;)</code></pre>
 </details>
-<h3>Class variables</h3>
-<dl>
-<dt id="supertokens_python.framework.flask.flask_middleware.Middleware.Flask"><code class="name">var <span class="ident">Flask</span></code></dt>
-<dd>
-<div class="desc"><p>The flask object implements a WSGI application and acts as the central
-object.
-It is passed the name of the module or package of the
-application.
-Once it is created it will act as a central registry for
-the view functions, the URL rules, template configuration and much more.</p>
-<p>The name of the package is used to resolve resources from inside the
-package or the folder the module is contained in depending on if the
-package parameter resolves to an actual python package (a folder with
-an :file:<code>__init__.py</code> file inside) or a standard module (just a <code>.py</code> file).</p>
-<p>For more information about resource loading, see :func:<code>open_resource</code>.</p>
-<p>Usually you create a :class:<code>Flask</code> instance in your main module or
-in the :file:<code>__init__.py</code> file of your package like this::</p>
-<pre><code>from flask import Flask
-app = Flask(__name__)
-</code></pre>
-<div class="admonition admonition">
-<p class="admonition-title">About the First Parameter</p>
-<p>The idea of the first parameter is to give Flask an idea of what
-belongs to your application.
-This name is used to find resources
-on the filesystem, can be used by extensions to improve debugging
-information and a lot more.</p>
-<p>So it's important what you provide there.
-If you are using a single
-module, <code>__name__</code> is always the correct value.
-If you however are
-using a package, it's usually recommended to hardcode the name of
-your package there.</p>
-<p>For example if your application is defined in :file:<code>yourapplication/app.py</code>
-you should create it with one of the two versions below::</p>
-<pre><code>app = Flask('yourapplication')
-app = Flask(__name__.split('.')[0])
-</code></pre>
-<p>Why is that?
-The application will work even with <code>__name__</code>, thanks
-to how resources are looked up.
-However it will make debugging more
-painful.
-Certain extensions can make assumptions based on the
-import name of your application.
-For example the Flask-SQLAlchemy
-extension will look for the code in your application that triggered
-an SQL query in debug mode.
-If the import name is not properly set
-up, that debugging information is lost.
-(For example it would only
-pick up SQL queries in <code>yourapplication.app</code> and not
-<code>yourapplication.views.frontend</code>)</p>
-</div>
-<div class="admonition versionadded">
-<p class="admonition-title">Added in version:&ensp;0.7</p>
-<p>The <code>static_url_path</code>, <code>static_folder</code>, and <code>template_folder</code>
-parameters were added.</p>
-</div>
-<div class="admonition versionadded">
-<p class="admonition-title">Added in version:&ensp;0.8</p>
-<p>The <code>instance_path</code> and <code>instance_relative_config</code> parameters were
-added.</p>
-</div>
-<div class="admonition versionadded">
-<p class="admonition-title">Added in version:&ensp;0.11</p>
-<p>The <code>root_path</code> parameter was added.</p>
-</div>
-<div class="admonition versionadded">
-<p class="admonition-title">Added in version:&ensp;1.0</p>
-<p>The <code>host_matching</code> and <code>static_host</code> parameters were added.</p>
-</div>
-<div class="admonition versionadded">
-<p class="admonition-title">Added in version:&ensp;1.0</p>
-<p>The <code>subdomain_matching</code> parameter was added. Subdomain
-matching needs to be enabled manually now. Setting
-:data:<code>SERVER_NAME</code> does not implicitly enable it.</p>
-</div>
-<p>:param import_name: the name of the application package
-:param static_url_path: can be used to specify a different path for the
-static files on the web.
-Defaults to the name
-of the <code>static_folder</code> folder.
-:param static_folder: The folder with static files that is served at
-<code>static_url_path</code>. Relative to the application <code>root_path</code>
-or an absolute path. Defaults to <code>'static'</code>.
-:param static_host: the host to use when adding the static route.
-Defaults to None. Required when using <code>host_matching=True</code>
-with a <code>static_folder</code> configured.
-:param host_matching: set <code>url_map.host_matching</code> attribute.
-Defaults to False.
-:param subdomain_matching: consider the subdomain relative to
-:data:<code>SERVER_NAME</code> when matching routes. Defaults to False.
-:param template_folder: the folder that contains the templates that should
-be used by the application.
-Defaults to
-<code>'templates'</code> folder in the root path of the
-application.
-:param instance_path: An alternative instance path for the application.
-By default the folder <code>'instance'</code> next to the
-package or module is assumed to be the instance
-path.
-:param instance_relative_config: if set to <code>True</code> relative filenames
-for loading the config are assumed to
-be relative to the instance path instead
-of the application root.
-:param root_path: The path to the root of the application files.
-This should only be set manually when it can't be detected
-automatically, such as for namespace packages.</p></div>
-</dd>
-</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="supertokens_python.framework.flask.flask_middleware.Middleware.set_before_after_request"><code class="name flex">
@@ -441,7 +332,6 @@ automatically, such as for namespace packages.</p></div>
 <li>
 <h4><code><a title="supertokens_python.framework.flask.flask_middleware.Middleware" href="#supertokens_python.framework.flask.flask_middleware.Middleware">Middleware</a></code></h4>
 <ul class="">
-<li><code><a title="supertokens_python.framework.flask.flask_middleware.Middleware.Flask" href="#supertokens_python.framework.flask.flask_middleware.Middleware.Flask">Flask</a></code></li>
 <li><code><a title="supertokens_python.framework.flask.flask_middleware.Middleware.set_before_after_request" href="#supertokens_python.framework.flask.flask_middleware.Middleware.set_before_after_request">set_before_after_request</a></code></li>
 <li><code><a title="supertokens_python.framework.flask.flask_middleware.Middleware.set_error_handler" href="#supertokens_python.framework.flask.flask_middleware.Middleware.set_error_handler">set_error_handler</a></code></li>
 </ul>

--- a/html/supertokens_python/framework/flask/framework.html
+++ b/html/supertokens_python/framework/flask/framework.html
@@ -39,15 +39,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.flask.flask_request import FlaskRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from flask.wrappers import Request
 
 
 class FlaskFramework(Framework):
-    from flask.wrappers import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.flask.flask_request import \
+            FlaskRequest
         return FlaskRequest(unwrapped)</code></pre>
 </details>
 </section>
@@ -71,9 +77,10 @@ inheritance.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class FlaskFramework(Framework):
-    from flask.wrappers import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.flask.flask_request import \
+            FlaskRequest
         return FlaskRequest(unwrapped)</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -81,26 +88,10 @@ inheritance.</p></div>
 <li><a title="supertokens_python.framework.types.Framework" href="../types.html#supertokens_python.framework.types.Framework">Framework</a></li>
 <li>abc.ABC</li>
 </ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="supertokens_python.framework.flask.framework.FlaskFramework.Request"><code class="name">var <span class="ident">Request</span></code></dt>
-<dd>
-<div class="desc"><p>The request object used by default in Flask.
-Remembers the
-matched endpoint and view arguments.</p>
-<p>It is what ends up as :class:<code>~flask.request</code>.
-If you want to replace
-the request object used you can subclass this and set
-:attr:<code>~flask.Flask.request_class</code> to your subclass.</p>
-<p>The request object is a :class:<code>~werkzeug.wrappers.Request</code> subclass and
-provides all of the attributes Werkzeug defines plus a few Flask
-specific ones.</p></div>
-</dd>
-</dl>
 <h3>Methods</h3>
 <dl>
 <dt id="supertokens_python.framework.flask.framework.FlaskFramework.wrap_request"><code class="name flex">
-<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: flask.wrappers.Request)</span>
+<span>def <span class="ident">wrap_request</span></span>(<span>self, unwrapped: Request)</span>
 </code></dt>
 <dd>
 <div class="desc"></div>
@@ -109,6 +100,8 @@ specific ones.</p></div>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def wrap_request(self, unwrapped: Request):
+    from supertokens_python.framework.flask.flask_request import \
+        FlaskRequest
     return FlaskRequest(unwrapped)</code></pre>
 </details>
 </dd>
@@ -133,7 +126,6 @@ specific ones.</p></div>
 <li>
 <h4><code><a title="supertokens_python.framework.flask.framework.FlaskFramework" href="#supertokens_python.framework.flask.framework.FlaskFramework">FlaskFramework</a></code></h4>
 <ul class="">
-<li><code><a title="supertokens_python.framework.flask.framework.FlaskFramework.Request" href="#supertokens_python.framework.flask.framework.FlaskFramework.Request">Request</a></code></li>
 <li><code><a title="supertokens_python.framework.flask.framework.FlaskFramework.wrap_request" href="#supertokens_python.framework.flask.framework.FlaskFramework.wrap_request">wrap_request</a></code></li>
 </ul>
 </li>

--- a/html/supertokens_python/recipe/passwordless/interfaces.html
+++ b/html/supertokens_python/recipe/passwordless/interfaces.html
@@ -42,13 +42,11 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Union
 
-from .types import DeviceType, User
-
-from typing_extensions import Literal
-
 from supertokens_python.framework import BaseRequest, BaseResponse
 from supertokens_python.recipe.session import SessionContainer
+from typing_extensions import Literal
 
+from .types import DeviceType, User
 from .utils import PasswordlessConfig
 
 
@@ -153,15 +151,18 @@ class ConsumeCodeResult(ABC):
                  failed_code_input_attempt_count: Union[int, None] = None,
                  maximum_code_input_attempts: Union[int, None] = None
                  ):
-        self.status = status
-        self.created_new_user = created_new_user
-        self.user = user
-        self.failed_code_input_attempt_count = failed_code_input_attempt_count
-        self.maximum_code_input_attempts = maximum_code_input_attempts
-        self.is_ok = False
-        self.is_incorrect_user_input_code_error = False
-        self.is_expired_user_input_code_error = False
-        self.is_restart_flow_error = False
+        self.status: Literal[&#39;OK&#39;,
+                             &#39;INCORRECT_USER_INPUT_CODE_ERROR&#39;,
+                             &#39;EXPIRED_USER_INPUT_CODE_ERROR&#39;,
+                             &#39;RESTART_FLOW_ERROR&#39;] = status
+        self.created_new_user: Union[bool, None] = created_new_user
+        self.user: Union[User, None] = user
+        self.failed_code_input_attempt_count: Union[int, None] = failed_code_input_attempt_count
+        self.maximum_code_input_attempts: Union[int, None] = maximum_code_input_attempts
+        self.is_ok: bool = False
+        self.is_incorrect_user_input_code_error: bool = False
+        self.is_expired_user_input_code_error: bool = False
+        self.is_restart_flow_error: bool = False
 
 
 class ConsumeCodeOkResult(ConsumeCodeResult):
@@ -1352,15 +1353,18 @@ inheritance.</p></div>
                  failed_code_input_attempt_count: Union[int, None] = None,
                  maximum_code_input_attempts: Union[int, None] = None
                  ):
-        self.status = status
-        self.created_new_user = created_new_user
-        self.user = user
-        self.failed_code_input_attempt_count = failed_code_input_attempt_count
-        self.maximum_code_input_attempts = maximum_code_input_attempts
-        self.is_ok = False
-        self.is_incorrect_user_input_code_error = False
-        self.is_expired_user_input_code_error = False
-        self.is_restart_flow_error = False</code></pre>
+        self.status: Literal[&#39;OK&#39;,
+                             &#39;INCORRECT_USER_INPUT_CODE_ERROR&#39;,
+                             &#39;EXPIRED_USER_INPUT_CODE_ERROR&#39;,
+                             &#39;RESTART_FLOW_ERROR&#39;] = status
+        self.created_new_user: Union[bool, None] = created_new_user
+        self.user: Union[User, None] = user
+        self.failed_code_input_attempt_count: Union[int, None] = failed_code_input_attempt_count
+        self.maximum_code_input_attempts: Union[int, None] = maximum_code_input_attempts
+        self.is_ok: bool = False
+        self.is_incorrect_user_input_code_error: bool = False
+        self.is_expired_user_input_code_error: bool = False
+        self.is_restart_flow_error: bool = False</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">

--- a/html/supertokens_python/recipe/thirdparty/providers/apple.html
+++ b/html/supertokens_python/recipe/thirdparty/providers/apple.html
@@ -169,8 +169,7 @@ class Apple(Provider):
         err = Exception(&#34;Id token verification failed&#34;)
         for key in public_keys:
             try:
-                decode(jwt=token, key=key,
-                       audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=[&#34;RS256&#34;])
+                decode(jwt=token, key=key, audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=[&#34;RS256&#34;])  # type: ignore
                 return
             except Exception as e:
                 err = e
@@ -304,8 +303,7 @@ inheritance.</p></div>
         err = Exception(&#34;Id token verification failed&#34;)
         for key in public_keys:
             try:
-                decode(jwt=token, key=key,
-                       audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=[&#34;RS256&#34;])
+                decode(jwt=token, key=key, audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=[&#34;RS256&#34;])  # type: ignore
                 return
             except Exception as e:
                 err = e

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ exclude_list = [
 
 setup(
     name="supertokens_python",
-    version="0.5.0",
+    version="0.5.1",
     author="SuperTokens",
     license="Apache 2.0",
     author_email="team@supertokens.io",

--- a/setup.py
+++ b/setup.py
@@ -16,19 +16,25 @@ extras_require = {
         'uvicorn==0.13.4',
         'requests==2.25.1',
         'pytest-asyncio==0.14.0',
-        'respx==0.16.3',
         'nest-asyncio==1.5.1',
-        'Fastapi==0.68.1',
-        'django==3.2.12',
-        'Flask==2.0.2',
         'python-dotenv==0.19.2',
-        'flask_cors',
-        'django-cors-headers==3.11.0',
         'pdoc3==0.10.0',
         'tzdata==2021.5',
         'pylint==2.12.2',
         'isort==5.10.1',
         'pyright==0.0.13',
+    ]),
+    'fastapi': ([
+        'respx==0.16.3',
+        'Fastapi==0.68.1'
+    ]),
+    'flask': ([
+        'flask_cors',
+        'Flask==2.0.2'
+    ]),
+    'django': ([
+        'django-cors-headers==3.11.0',
+        'django==3.2.12',
         'django-stubs==1.9.0'
     ])
 }

--- a/supertokens_python/constants.py
+++ b/supertokens_python/constants.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 SUPPORTED_CDI_VERSIONS = ['2.9', '2.10', '2.11', '2.12']
-VERSION = '0.5.0'
+VERSION = '0.5.1'
 TELEMETRY = '/telemetry'
 USER_COUNT = '/users/count'
 USER_DELETE = '/user/remove'

--- a/supertokens_python/framework/django/django_response.py
+++ b/supertokens_python/framework/django/django_response.py
@@ -48,7 +48,7 @@ class DjangoResponse(BaseResponse):
             key=key,
             value=value,
             expires=datetime.fromtimestamp(
-                ceil(expires / 1000)).strftime("%A, %B %d, %Y %I:%M:%S"),
+                ceil(expires / 1000)).strftime("%A, %B %d, %Y %H:%M:%S"),
             path=path,
             domain=domain,
             secure=secure,

--- a/supertokens_python/framework/django/framework.py
+++ b/supertokens_python/framework/django/framework.py
@@ -12,12 +12,19 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from supertokens_python.framework.django.django_request import DjangoRequest
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 
 class DjangoFramework(Framework):
-    from django.http import HttpRequest
 
     def wrap_request(self, unwrapped: HttpRequest):
+        from supertokens_python.framework.django.django_request import \
+            DjangoRequest
         return DjangoRequest(unwrapped)

--- a/supertokens_python/framework/fastapi/fastapi_middleware.py
+++ b/supertokens_python/framework/fastapi/fastapi_middleware.py
@@ -11,16 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from starlette.middleware.base import (BaseHTTPMiddleware,
                                        RequestResponseEndpoint)
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
+
 
 class Middleware(BaseHTTPMiddleware):
-    from fastapi import FastAPI, Request
 
     def __init__(self, app: FastAPI):
         super().__init__(app)

--- a/supertokens_python/framework/fastapi/framework.py
+++ b/supertokens_python/framework/fastapi/framework.py
@@ -11,13 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.fastapi.fastapi_request import FastApiRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 class FastapiFramework(Framework):
-    from fastapi import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.fastapi.fastapi_request import \
+            FastApiRequest
         return FastApiRequest(unwrapped)

--- a/supertokens_python/framework/flask/flask_middleware.py
+++ b/supertokens_python/framework/flask/flask_middleware.py
@@ -11,16 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from supertokens_python.async_to_sync_wrapper import sync
 from supertokens_python.framework import BaseResponse
 
+if TYPE_CHECKING:
+    from flask import Flask
+
 
 class Middleware:
-    from flask import Flask
 
     def __init__(self, app: Flask):
         self.app = app

--- a/supertokens_python/framework/flask/framework.py
+++ b/supertokens_python/framework/flask/framework.py
@@ -11,13 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from supertokens_python.framework.flask.flask_request import FlaskRequest
+from typing import TYPE_CHECKING
+
 from supertokens_python.framework.types import Framework
+
+if TYPE_CHECKING:
+    from flask.wrappers import Request
 
 
 class FlaskFramework(Framework):
-    from flask.wrappers import Request
 
     def wrap_request(self, unwrapped: Request):
+        from supertokens_python.framework.flask.flask_request import \
+            FlaskRequest
         return FlaskRequest(unwrapped)

--- a/supertokens_python/recipe/passwordless/interfaces.py
+++ b/supertokens_python/recipe/passwordless/interfaces.py
@@ -14,13 +14,11 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Union
 
-from .types import DeviceType, User
-
-from typing_extensions import Literal
-
 from supertokens_python.framework import BaseRequest, BaseResponse
 from supertokens_python.recipe.session import SessionContainer
+from typing_extensions import Literal
 
+from .types import DeviceType, User
 from .utils import PasswordlessConfig
 
 
@@ -125,15 +123,18 @@ class ConsumeCodeResult(ABC):
                  failed_code_input_attempt_count: Union[int, None] = None,
                  maximum_code_input_attempts: Union[int, None] = None
                  ):
-        self.status = status
-        self.created_new_user = created_new_user
-        self.user = user
-        self.failed_code_input_attempt_count = failed_code_input_attempt_count
-        self.maximum_code_input_attempts = maximum_code_input_attempts
-        self.is_ok = False
-        self.is_incorrect_user_input_code_error = False
-        self.is_expired_user_input_code_error = False
-        self.is_restart_flow_error = False
+        self.status: Literal['OK',
+                             'INCORRECT_USER_INPUT_CODE_ERROR',
+                             'EXPIRED_USER_INPUT_CODE_ERROR',
+                             'RESTART_FLOW_ERROR'] = status
+        self.created_new_user: Union[bool, None] = created_new_user
+        self.user: Union[User, None] = user
+        self.failed_code_input_attempt_count: Union[int, None] = failed_code_input_attempt_count
+        self.maximum_code_input_attempts: Union[int, None] = maximum_code_input_attempts
+        self.is_ok: bool = False
+        self.is_incorrect_user_input_code_error: bool = False
+        self.is_expired_user_input_code_error: bool = False
+        self.is_restart_flow_error: bool = False
 
 
 class ConsumeCodeOkResult(ConsumeCodeResult):

--- a/supertokens_python/recipe/thirdparty/providers/apple.py
+++ b/supertokens_python/recipe/thirdparty/providers/apple.py
@@ -141,8 +141,7 @@ class Apple(Provider):
         err = Exception("Id token verification failed")
         for key in public_keys:
             try:
-                decode(jwt=token, key=key,
-                       audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=["RS256"])
+                decode(jwt=token, key=key, audience=[get_actual_client_id_from_development_client_id(self.client_id)], algorithms=["RS256"])  # type: ignore
                 return
             except Exception as e:
                 err = e


### PR DESCRIPTION
Closes #10 

Tests output:

```
$ python -m pytest -s tests
========== test session starts ==========t
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/infante/Documents/projects/supertokens/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/infante/Documents/projects/supertokens, configfile: pytest.ini
plugins: asyncio-0.18.1
asyncio: mode=legacy
collected 85 items                                                                                                               

tests/test_config.py::testing_URL_path_normalisation PASSED
tests/test_config.py::testing_URL_domain_normalisation PASSED
tests/test_config.py::test_same_site_values PASSED/home/infante/.pyenv/versions/3.10.2/lib/python3.10/asyncio/base_events.py:666: RuntimeWarning: coroutine 'RecipeImplementation.__init__.<locals>.call_get_handshake_info' was never awaited
  self._ready.clear()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback

tests/test_config.py::test_config_values PASSED
tests/test_config.py::testing_override_test PASSED
tests/test_config.py::testing_super_recipe_tests PASSED
tests/test_handshake.py::test_that_once_the_info_is_loaded_it_doesnt_query_again PASSED
tests/test_middleware.py::test_rid_with_session_and_non_existent_api_in_session_recipe_gives_404 PASSED
tests/test_middleware.py::test_no_rid_with_existent_API_does_not_give_404 PASSED
tests/test_middleware.py::test_rid_as_anticsrf_with_existent_API_does_not_give_404 PASSED
tests/test_middleware.py::test_random_rid_with_existent_API_does_gives_404 /home/infante/Documents/projects/supertokens/.venv/lib/python3.10/site-packages/requests/sessions.py:755: RuntimeWarning: coroutine 'Semaphore.acquire' was never awaited
  keys_to_move = [k for k in self.adapters if len(k) < len(prefix)]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
PASSED
tests/test_session.py::test_that_once_the_info_is_loaded_it_doesnt_query_again /home/infante/Documents/projects/supertokens/.venv/lib/python3.10/site-packages/cffi/cparser.py:723: RuntimeWarning: coroutine 'Semaphore.acquire' was never awaited
  args = [self._as_func_arg(*self._get_type_and_quals(argdeclnode.type))
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
PASSED
tests/test_user_context.py::test_user_context PASSED
tests/Django/test_django.py::SupertokensTest::test_custom_response PASSED
tests/Django/test_django.py::SupertokensTest::test_login_handle PASSED
tests/Django/test_django.py::SupertokensTest::test_login_logout PASSED
tests/Django/test_django.py::SupertokensTest::test_login_refresh PASSED
tests/Django/test_django.py::SupertokensTest::test_login_refresh_error_handler PASSED
tests/Falcon/test_falconapi.py::test_login_refresh PASSED
tests/Falcon/test_falconapi.py::test_login_logout 2022-03-03 08:52:36,436 - falcon-middleware - INFO - Authorization Error: Session does not exist. Are you sending the session tokens in the request as cookies?
PASSED
tests/Falcon/test_falconapi.py::test_logout_wrong_credentials 2022-03-03 08:52:42,100 - falcon-middleware - INFO - Authorization Error: invalid jwt
PASSED
tests/Falcon/test_falconapi.py::test_login_info PASSED
tests/Falcon/test_falconapi.py::test_login_handle PASSED
tests/Falcon/test_falconapi.py::test_login_refresh_error_handler PASSED
tests/Fastapi/test_fastapi.py::test_login_refresh PASSED
tests/Fastapi/test_fastapi.py::test_login_logout PASSED
tests/Fastapi/test_fastapi.py::test_login_info PASSED
tests/Fastapi/test_fastapi.py::test_login_handle PASSED
tests/Fastapi/test_fastapi.py::test_login_refresh_error_handler PASSED
tests/Fastapi/test_fastapi.py::test_custom_response PASSED
tests/Flask/test_flask.py::test_cookie_login_and_refresh PASSED
tests/Flask/test_flask.py::test_login_refresh_no_csrf PASSED
tests/Flask/test_flask.py::test_login_logout PASSED
tests/Flask/test_flask.py::test_login_handle PASSED
tests/Flask/test_flask.py::test_custom_response PASSED
tests/emailpassword/test_emailexists.py::test_good_input_email_exists PASSED
tests/emailpassword/test_emailexists.py::test_good_input_email_does_not_exists PASSED
tests/emailpassword/test_emailexists.py::test_that_if_disabling_api_the_default_email_exists_api_does_not_work PASSED
tests/emailpassword/test_emailexists.py::test_email_exists_a_syntactically_invalid_email PASSED
tests/emailpassword/test_emailexists.py::test_sending_an_unnormalised_email_and_you_get_exists_is_true PASSED
tests/emailpassword/test_emailexists.py::test_bad_input_do_not_pass_email PASSED
tests/emailpassword/test_emailexists.py::test_passing_an_array_instead_of_a_string_in_the_email PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_valid_input_email_not_verified PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_valid_input_email_verified_and_test_error PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_valid_input_no_session_and_check_output PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_an_expired_access_token_and_see_that_try_refresh_token_is_returned PASSED
tests/emailpassword/test_emailverify.py::test_that_providing_your_own_email_callback_and_make_sure_it_is_called /home/infante/Documents/projects/supertokens/.venv/lib/python3.10/site-packages/httpx/_utils.py:413: RuntimeWarning: coroutine 'Semaphore.acquire' was never awaited
  self.started = await self._get_time()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_api_with_valid_input PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_api_with_invalid_token_and_check_error PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_api_with_token_of_not_type_string PASSED
tests/emailpassword/test_emailverify.py::test_that_the_handle_post_email_verification_callback_is_called_on_successful_verification_if_given PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_with_valid_input_using_the_get_method PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_with_no_session_using_the_get_method PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_api_with_valid_input_overriding_apis PASSED
tests/emailpassword/test_emailverify.py::test_the_email_verify_api_with_valid_input_overriding_apis_throws_error PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_valid_input_and_then_remove_token PASSED
tests/emailpassword/test_emailverify.py::test_the_generate_token_api_with_valid_input_verify_and_then_unverify_email PASSED
tests/emailpassword/test_passwordreset.py::test_email_validation_checks_in_generate_token_API PASSED
tests/emailpassword/test_passwordreset.py::test_that_generated_password_link_is_correct /home/infante/.pyenv/versions/3.10.2/lib/python3.10/asyncio/base_events.py:149: RuntimeWarning: coroutine 'Semaphore.acquire' was never awaited
  socket.inet_pton(af, host)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
PASSED
tests/emailpassword/test_passwordreset.py::test_password_validation PASSED
tests/emailpassword/test_passwordreset.py::test_token_missing_from_input PASSED
tests/emailpassword/test_passwordreset.py::test_valid_token_input_and_passoword_has_changed PASSED
tests/emailpassword/test_signin.py::test_that_disabling_api_the_default_signin_API_does_not_work PASSED
tests/emailpassword/test_signin.py::test_singinAPI_works_when_input_is_fine PASSED
tests/emailpassword/test_signin.py::test_singinAPI_throws_an_error_when_email_does_not_match PASSED
tests/emailpassword/test_signin.py::test_singin_api_throws_an_error_when_email_does_not_match PASSED
tests/emailpassword/test_signin.py::test_singinAPI_throws_an_error_if_password_is_incorrect PASSED
tests/emailpassword/test_signin.py::test_bad_input_not_a_JSON_to_signin_api PASSED
tests/emailpassword/test_signin.py::test_bad_input_not_a_JSON_to_signin_API PASSED
tests/emailpassword/test_signin.py::test_that_a_successful_signin_yields_a_session PASSED
tests/emailpassword/test_signin.py::test_email_field_validation_error PASSED
tests/emailpassword/test_signin.py::test_formFields_has_no_email_field PASSED
tests/emailpassword/test_signin.py::test_formFields_has_no_password_field PASSED
tests/emailpassword/test_signin.py::test_delete_user PASSED
tests/jwt/test_config.py::test_that_the_default_config_sets_values_correctly_for_JWT_recipe PASSED
tests/jwt/test_config.py::test_that_the_config_sets_values_correctly_for_JWT_recipe_when_jwt_validity_is_set PASSED
tests/jwt/test_create_jwt_feature.py::test_that_sending_0_validity_throws_an_error PASSED
tests/jwt/test_create_jwt_feature.py::test_that_sending_a_invalid_json_throws_an_error PASSED
tests/jwt/test_create_jwt_feature.py::test_that_returned_JWT_uses_100_years_for_expiry_for_default_config PASSED
tests/jwt/test_create_jwt_feature.py::test_that_jwt_validity_is_same_as_validity_set_in_config PASSED
tests/jwt/test_create_jwt_feature.py::test_that_jwt_validity_is_same_as_validity_passed_in_createJWT_function PASSED
tests/jwt/test_get_JWKS.py::test_that_default_getJWKS_api_does_not_work_when_disabled PASSED
tests/jwt/test_get_JWKS.py::test_that_default_getJWKS_works_fine PASSED
tests/jwt/test_override.py::test_that_default_getJWKS_api_does_not_work_when_disabled PASSED
tests/jwt/test_override.py::test_overriding_APIs PASSED

========= 85 passed in 513.85s (0:08:33) =========
```